### PR TITLE
Add freud analysis library

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,13 @@
 ## Trajectory Analysis
 
 * [CppTraj](https://github.com/Amber-MD/cpptraj) - Biomolecular simulation trajectory/data analysis.
+* [Freud](https://freud.readthedocs.io/en/stable/) - Parallel, python-based analysis with an emphasis on local particle environments. [:octocat:][freud-code][:book:][freud-doc]
 * [MDAnalysis](https://www.mdanalysis.org/) - An object-oriented Python library to analyze trajectories from molecular dynamics (MD) simulations in many popular formats.
 * [MDTraj](http://mdtraj.org/) - A python library that allows users to manipulate molecular dynamics (MD) trajectories.
 * [PyTraj](https://amber-md.github.io/pytraj/) - A Python front-end of [CppTraj](https://github.com/Amber-MD/cpptraj).
+
+[freud-code]: https://github.com/glotzerlab/freud
+[freud-doc]: https://freud.readthedocs.io/
 
 ## Visualization Tools
 


### PR DESCRIPTION
Freud is an efficient, parallel python library for analysis of simulation data. It includes many standard types of analysis (RDF and MSD type calculations, Steinhardt order parameters, and so on) as well as more specialized analysis of particle local environments (potentials of mean force and torque, local environment graph matching, local spherical harmonic descriptors) that have not yet been implemented elsewhere.