### PR TITLE
Add plato visualization package

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,15 @@
 
 * [Avogadro](https://avogadro.cc/) - An advanced molecule editor and visualizer designed for cross-platform use in computational chemistry, molecular modeling, bioinformatics, materials science, and related areas. [:octocat:][avogadro-code][:book:][avogadro-doc]
 * [VMD](http://www.ks.uiuc.edu/Research/vmd/) - A molecular visualization program for displaying, animating, and analyzing large biomolecular systems using 3-D graphics and built-in scripting. [:book:][vmd-doc]
+* [Plato](https://plato-draw.readthedocs.io/) - A python library for both interactive and figure-grade visualizations of particle systems. [:octocat:][plato-code][:book:][plato-doc]
 * [PyMOL](https://pymol.org/2/) - A user-sponsored molecular visualization system on an open-source foundation, maintained and distributed by Schrödinger. [:book:][pymol-doc]
 * [OVITO](https://ovito.org/) - OVITO is a scientific visualization and analysis software for atomistic and particle simulation data. [:book:][ovito-doc]
 
 [avogadro-code]: https://github.com/cryos/avogadro
 [avogadro-doc]: https://avogadro.cc/docs/
 [vmd-doc]: http://www.ks.uiuc.edu/Research/vmd/current/docs.html
+[plato-code]: https://github.com/glotzerlab/plato
+[plato-doc]: https://plato-draw.readthedocs.io
 [pymol-doc]: http://pymol.sourceforge.net/newman/userman.pdf
 [ovito-doc]: http://www.ovito.org/manual/
 


### PR DESCRIPTION
Plato is a python visualization package for rendering collections of particles. It supports a number of rendering backends that span use cases from interactive, quick visualization in a GUI to carefully-crafted, high-quality images for paper figures. It also supports interactive rendering in jupyter notebooks via [vispy](http://vispy.org/).